### PR TITLE
Adding gc-percentage calculation and reporting to stdout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:  # Define jobs for the workflow
           # Save the expected output to a file
           echo "Processing FASTQ file: ./data/sample.fastq" > expected_output.txt
           echo "Number of reads in ./data/sample.fastq: 2" >> expected_output.txt
+          echo "GC Percent in ./data/sample.fastq 0.5 : 2" >> expected_output.txt
 
           # Capture the actual output of the script and save it to a file
           ./bin/fastq-peek.sh ./data/sample.fastq > actual_output.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:  # Define jobs for the workflow
           # Save the expected output to a file
           echo "Processing FASTQ file: ./data/sample.fastq" > expected_output.txt
           echo "Number of reads in ./data/sample.fastq: 2" >> expected_output.txt
-          echo "GC Percent in ./data/sample.fastq 0.5 : 2" >> expected_output.txt
+          echo "GC Percent in ./data/sample.fastq: 0.5" >> expected_output.txt
 
           # Capture the actual output of the script and save it to a file
           ./bin/fastq-peek.sh ./data/sample.fastq > actual_output.txt

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -27,15 +27,14 @@ echo "Processing FASTQ file: $FASTQ_FILE"
 LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 ## Calculate the number of reads (4 lines per read)
 READ_COUNT=$((LINE_COUNT / 4))
-
 ## Count GC in FASTQ file
 GC_COUNT=$(awk '(NR%4==2) {gsub(/[ATnNat]/,"");N+=length($0);}END{print N;}' "$FASTQ_FILE")
-
 ## Count total number of bases in FASTQ file
 TOTAL_BASE_COUNT=$(awk 'NR%4==2 {sum += length($0)} END {print sum}' "$FASTQ_FILE")
-
 ## Calculate GC percent in FASTQ file
 GC_PERCENT=$(awk '(NR%4==2) {N1+=length($0);gsub(/[AT]/,"");N2+=length($0);}END{print N2/N1;}' "$FASTQ_FILE")
 
 # Print results to terminal
 echo -e "Number of reads in $FASTQ_FILE: $READ_COUNT\nGC Percent in $FASTQ_FILE: $GC_PERCENT"
+
+exit 0

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Holly Halstead 
+# Western-WFD-2024 Week 01 Exercise
+
 # Get the directory of the current script
 SCRIPT_DIR=$(dirname "$0")
 
@@ -25,4 +28,14 @@ LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 ## Calculate the number of reads (4 lines per read)
 READ_COUNT=$((LINE_COUNT / 4))
 
-echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+## Count GC in FASTQ file
+GC_COUNT=$(awk '(NR%4==2) {gsub(/[ATnNat]/,"");N+=length($0);}END{print N;}' "$FASTQ_FILE")
+
+## Count total number of bases in FASTQ file
+TOTAL_BASE_COUNT=$(awk 'NR%4==2 {sum += length($0)} END {print sum}' "$FASTQ_FILE")
+
+## Calculate GC percent in FASTQ file
+GC_PERCENT=$(awk '(NR%4==2) {N1+=length($0);gsub(/[AT]/,"");N2+=length($0);}END{print N2/N1;}' "$FASTQ_FILE")
+
+# Print results to terminal
+echo -e "Number of reads in $FASTQ_FILE: $READ_COUNT\nGC Percent in $FASTQ_FILE: $GC_PERCENT"


### PR DESCRIPTION
## Description 
fastq-peek was edited to calculate GC_COUNT, TOTAL_BASE_COUNT, and GC_PERCENT; reports GC_PERCENT to stdout

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Yes:
Script was tested with the following command locally:
```bash ./bin/fastq-peek.sh ./data/sample.fastq```

and yields in stdout:
```
Processing FASTQ file: sample.fastq
Number of reads in sample.fastq: 2
GC Percent in sample.fastq: 0.5
```

## Checklist:
- [X] My code adheres to the [repository style guide](https://github.com/theiagen/Western-WFD-2024/blob/main/style-guide.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
